### PR TITLE
FIX: ensure that the URL is not overridden by the plugin

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -19,6 +19,7 @@ require_relative "lib/discourse_open_graph/engine"
 after_initialize do
   overrides = DiscourseOpenGraph::OpenGraphOverrides.new
   register_modifier(:meta_data_content) do |content, property, opts|
+    next content if property == :url # we don't want to override the url
     url = opts[:url]
     override = overrides.find_by_url(url)
     if override

--- a/spec/requests/plugin_spec.rb
+++ b/spec/requests/plugin_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe DiscourseOpenGraph do
   fab!(:news_tag) { Fabricate(:tag, name: "news") }
   fab!(:category)
 
+  def og_url
+    response.body.match(/<meta property="og:url" content="(.*?)"/)[1].to_s
+  end
+
   def og_title
     response.body.match(/<meta property="og:title" content="(.*?)"/)[1].to_s
   end
@@ -72,6 +76,13 @@ RSpec.describe DiscourseOpenGraph do
 
       expect(twitter_title).to eq("This is official")
       expect(twitter_description).to eq("This is official")
+    end
+
+    it "does not affect the url meta tag" do
+      official_post = Fabricate(:post, topic: Fabricate(:topic, title: "This is a official post"))
+      get official_post.url
+
+      expect(og_url).to eq("#{Discourse.base_url_no_prefix}#{official_post.url}")
     end
   end
 end


### PR DESCRIPTION
Without this fix, the URL is overridden by the plugin when the plugin is enabled.

The URL is overridden by the plugin url regex